### PR TITLE
Add Expo-based Unitize app skeleton

### DIFF
--- a/unitize_app/App.js
+++ b/unitize_app/App.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import HomeScreen from './components/HomeScreen';
+import MyProjectsScreen from './components/MyProjectsScreen';
+import ProjectsScreen from './components/ProjectsScreen';
+import ServicesScreen from './components/ServicesScreen';
+import SettingsScreen from './components/SettingsScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Home" component={HomeScreen} />
+        <Tab.Screen name="My Projects" component={MyProjectsScreen} />
+        <Tab.Screen name="Projects" component={ProjectsScreen} />
+        <Tab.Screen name="Services" component={ServicesScreen} />
+        <Tab.Screen name="Settings" component={SettingsScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/unitize_app/README.md
+++ b/unitize_app/README.md
@@ -1,0 +1,16 @@
+# Unitize Mobile App (Expo)
+
+This is a lightweight Expo/React Native skeleton for the Unitize application.
+
+## Available Screens
+- Home with dashboard, quick actions, and sample project/group lists
+- My Projects
+- Projects
+- Unitize Services
+- Settings
+
+## Getting Started
+```bash
+npm install
+npm start
+```

--- a/unitize_app/components/HomeScreen.js
+++ b/unitize_app/components/HomeScreen.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+
+function DashboardCard() {
+  return (
+    <View style={styles.dashboard}>
+      <Text style={styles.dashboardTitle}>Project Stages</Text>
+      <Text>Documents & Licenses → Execution → Title Deed</Text>
+    </View>
+  );
+}
+
+function QuickActions() {
+  const actions = [
+    { title: 'My Groups' },
+    { title: 'Deposit' },
+    { title: 'Withdraw' },
+    { title: 'Upgrade' }
+  ];
+  return (
+    <View style={styles.quickActions}>
+      {actions.map(action => (
+        <TouchableOpacity key={action.title} style={styles.quickActionButton}>
+          <Text style={styles.quickActionText}>{action.title}</Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+export default function HomeScreen() {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <DashboardCard />
+      <QuickActions />
+      <Section title="Latest Projects">
+        <Text>Sample Project A – Riyadh – 80% funded</Text>
+        <Text>Sample Project B – Jeddah – 40% funded</Text>
+      </Section>
+      <Section title="Latest Groups">
+        <Text>North Riyadh Villas</Text>
+        <Text>Jeddah Apartments</Text>
+      </Section>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    backgroundColor: '#fff'
+  },
+  dashboard: {
+    backgroundColor: '#315A9B',
+    padding: 20,
+    borderRadius: 8,
+    marginBottom: 16
+  },
+  dashboardTitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8
+  },
+  quickActions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 16
+  },
+  quickActionButton: {
+    backgroundColor: '#e6e6e6',
+    padding: 10,
+    borderRadius: 8,
+    flex: 1,
+    marginHorizontal: 4,
+    alignItems: 'center'
+  },
+  quickActionText: {
+    fontSize: 12
+  },
+  section: {
+    marginBottom: 24
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 8
+  }
+});

--- a/unitize_app/components/MyProjectsScreen.js
+++ b/unitize_app/components/MyProjectsScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function MyProjectsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>My Projects will appear here.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  text: {
+    fontSize: 16
+  }
+});

--- a/unitize_app/components/ProjectsScreen.js
+++ b/unitize_app/components/ProjectsScreen.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ProjectsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Browse all projects here.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  text: {
+    fontSize: 16
+  }
+});

--- a/unitize_app/components/ServicesScreen.js
+++ b/unitize_app/components/ServicesScreen.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const services = [
+  'Design Purchase',
+  'Land Purchase',
+  'Consultation Request',
+  'Financing Calculator',
+  'Construction Calculator'
+];
+
+export default function ServicesScreen() {
+  return (
+    <View style={styles.container}>
+      {services.map(service => (
+        <Text key={service} style={styles.item}>{service}</Text>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16
+  },
+  item: {
+    fontSize: 16,
+    marginBottom: 8
+  }
+});

--- a/unitize_app/components/SettingsScreen.js
+++ b/unitize_app/components/SettingsScreen.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const settings = [
+  'Profile',
+  'Security',
+  'Notifications',
+  'Language',
+  'Log Out'
+];
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      {settings.map(item => (
+        <Text key={item} style={styles.item}>{item}</Text>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16
+  },
+  item: {
+    fontSize: 16,
+    marginBottom: 8
+  }
+});

--- a/unitize_app/package.json
+++ b/unitize_app/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "unitize_app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "test": "echo \"No test specified\""
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "^18.2.0",
+    "react-native": "^0.73.0",
+    "@react-navigation/native": "^6.1.10",
+    "@react-navigation/bottom-tabs": "^6.5.7"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Unitize mobile app with Expo and bottom tab navigation
- implement home screen with dashboard, quick actions, and sample project/group sections
- add service, project, and settings placeholder screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c29184c832994aa245b07efa324