### PR TITLE
Add React dashboard project with routing and theme

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.dist
+.vite
+coverage

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dashboard",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.5",
+    "vitest": "^1.0.0"
+  }
+}

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import DashboardPage from './pages/Dashboard';
+import AppDemoPage from './pages/AppDemo';
+
+function App() {
+  return (
+    <Router>
+      <Routes>
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/app-demo" element={<AppDemoPage />} />
+      </Routes>
+    </Router>
+  );
+}
+
+export default App;

--- a/dashboard/src/main.jsx
+++ b/dashboard/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/variables.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/dashboard/src/pages/AppDemo.jsx
+++ b/dashboard/src/pages/AppDemo.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function AppDemo() {
+  return (
+    <div style={{ backgroundColor: 'var(--color-background)', color: 'var(--color-secondary)', padding: '1rem' }}>
+      <h2>App Demo</h2>
+      <p>Demo component using secondary color.</p>
+    </div>
+  );
+}

--- a/dashboard/src/pages/Dashboard.jsx
+++ b/dashboard/src/pages/Dashboard.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Dashboard() {
+  return (
+    <div style={{ backgroundColor: 'var(--color-background)', color: 'var(--color-primary)', padding: '1rem' }}>
+      <h2>Dashboard</h2>
+      <p>Welcome to the dashboard.</p>
+    </div>
+  );
+}

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -1,0 +1,5 @@
+:root {
+  --color-primary: #5a67d8;
+  --color-secondary: #48bb78;
+  --color-background: #f7fafc;
+}

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold `dashboard` Vite React app
- add color variables and use them via CSS variables
- set up React Router routes `/dashboard` and `/app-demo`

## Testing
- `npm install` *(fails: 403 Forbidden to registry)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac55b5d6fc832998579b5a5b7d93da